### PR TITLE
Override home realm discovery IdP lookup mechanism

### DIFF
--- a/src/main/java/io/phasetwo/service/auth/idp/HomeIdpDiscoverer.java
+++ b/src/main/java/io/phasetwo/service/auth/idp/HomeIdpDiscoverer.java
@@ -111,10 +111,25 @@ final class HomeIdpDiscoverer {
                 .filter(IdentityProviderModel::isEnabled)
                 .collect(Collectors.toList()); */
 
+        // Custom Fastly lookup mechanism.
+        //
+        // 1. Get all Orgs linked to the user
+        // 3. Filter orgs based on inbound client (i.e. only return Sig-Sci orgs for sig-sci client etc)
+        // 2. Filter for enabled
+        // 4. Sort by users default_cid
+        String clientID = context.getAuthenticationSession().getClient().getClientId();
         OrganizationProvider orgs = context.getSession().getProvider(OrganizationProvider.class);
         List<IdentityProviderModel> enabledIdpsWithMatchingDomain =
             orgs.getUserOrganizationsStream(
                     context.getRealm(), user)
+                .filter(o -> {
+                    if(clientID.equals("sigsci-dashboard")) {
+                        String corp = o.getFirstAttribute("corp_id");
+                        return corp != null && !corp.isEmpty();
+                    }
+                    String cid = o.getFirstAttribute("customer_id");
+                    return cid != null && !cid.isEmpty();
+                })
                 .flatMap(o -> o.getIdentityProvidersStream())
                 .filter(IdentityProviderModel::isEnabled)
                 .collect(Collectors.toList());

--- a/src/main/java/io/phasetwo/service/auth/idp/HomeIdpDiscoverer.java
+++ b/src/main/java/io/phasetwo/service/auth/idp/HomeIdpDiscoverer.java
@@ -103,10 +103,18 @@ final class HomeIdpDiscoverer {
             config);
         */
         // Overidden lookup mechanism to lookup via organization domain
-        OrganizationProvider orgs = context.getSession().getProvider(OrganizationProvider.class);
+        /* OrganizationProvider orgs = context.getSession().getProvider(OrganizationProvider.class);
         List<IdentityProviderModel> enabledIdpsWithMatchingDomain =
             orgs.getOrganizationsStreamForDomain(
                     context.getRealm(), domain.toString(), config.requireVerifiedDomain())
+                .flatMap(o -> o.getIdentityProvidersStream())
+                .filter(IdentityProviderModel::isEnabled)
+                .collect(Collectors.toList()); */
+
+        OrganizationProvider orgs = context.getSession().getProvider(OrganizationProvider.class);
+        List<IdentityProviderModel> enabledIdpsWithMatchingDomain =
+            orgs.getUserOrganizationsStream(
+                    context.getRealm(), user)
                 .flatMap(o -> o.getIdentityProvidersStream())
                 .filter(IdentityProviderModel::isEnabled)
                 .collect(Collectors.toList());


### PR DESCRIPTION
⚠️ This is a PR into Fastly's base branch `fastly` and not the upstream origin.

### TL;DR
This refactors the logic used to lookup IdPs during the home realm discovery authenticator.

- Lookup orgs based on the users full email, not the domain
- Filter orgs based on the inbound client ID
    - i.e only select orgs with a `corp_id` attribute for the `sig-sci-dashboard` client, and orgs with a `customer_id` for the other Fastly clients
- Filter to only enabled IdPs