### PR TITLE
Disable home realm discovery fallback logic

### DIFF
--- a/src/main/java/io/phasetwo/service/auth/idp/HomeIdpDiscoverer.java
+++ b/src/main/java/io/phasetwo/service/auth/idp/HomeIdpDiscoverer.java
@@ -141,7 +141,7 @@ final class HomeIdpDiscoverer {
         // Prefer linked IdP with matching domain first
         List<IdentityProviderModel> homeIdps = getLinkedIdpsFrom(enabledIdpsWithMatchingDomain, linkedIdps);
 
-        if (homeIdps.isEmpty()) {
+        /* if (homeIdps.isEmpty()) {
             if (!linkedIdps.isEmpty()) {
                 // Prefer linked and enabled IdPs without matching domain in favor of not linked IdPs with matching domain
                 homeIdps = getLinkedIdpsFrom(enabledIdps, linkedIdps);
@@ -155,7 +155,9 @@ final class HomeIdpDiscoverer {
             }
         } else {
             logFoundIdps("linked", "matching", homeIdps, domain, username);
-        }
+        } */
+
+        logFoundIdps("linked", "matching", homeIdps, domain, username);
 
         return homeIdps;
     }


### PR DESCRIPTION
⚠️ This is a PR into Fastly's base branch `fastly` and not the upstream origin's `main`.

### TL;DR
Remove (comment out) fallback logic in the home realm discovery which meant that we would fallback to using any of the users linked IdPs if no desired (org has force sso, and is enabled) IdP is found.

This meant that users with no orgs/idp's with force sso enabled were still being redirected to linked IdPs. Which is not our desired behaviour.