### PR TITLE
Remove lowercasing logic from the searchForOrgs attirbutes predicate …

### DIFF
--- a/src/main/java/io/phasetwo/service/model/jpa/JpaOrganizationProvider.java
+++ b/src/main/java/io/phasetwo/service/model/jpa/JpaOrganizationProvider.java
@@ -248,8 +248,8 @@ public class JpaOrganizationProvider implements OrganizationProvider {
 
           attributePredicates.add(
               builder.and(
-                  builder.equal(builder.lower(attributesJoin.get("name")), key.toLowerCase()),
-                  builder.equal(builder.lower(attributesJoin.get("value")), value.toLowerCase())));
+                  builder.equal(attributesJoin.get("name"), key),
+                  builder.equal(attributesJoin.get("value"), value)));
           break;
       }
     }


### PR DESCRIPTION
⚠️ This is a PR into Fastly's base branch `fastly` and not the upstream origin's `main`.

---

### What?
Removes the `lowercase()` logic from attribute serach predicates for the `searchForOrganizationStream` query builder. I.e. don't get the RDMS engine to lowercase the column value before comparing in the `WHERE` clause predicate when scanning the table.

### Why?
We've observed slowness with queries produced by this query builder, especially when searching for orgs by attributes in databases with a large volume of orgs and org attributes.

An example query produced by the builder is:
```sql
SELECT o1_0.ID,o1_0.CREATED_BY_USER_ID,o1_0.DISPLAY_NAME,o1_0.NAME,o1_0.REALM_ID,o1_0.URL 
FROM ORGANIZATION o1_0 
LEFT JOIN ORGANIZATION_ATTRIBUTE a1_0 ON o1_0.ID=a1_0.ORGANIZATION_ID 
WHERE lower(a1_0.NAME)=? AND lower(a1_0.VALUE)=? AND o1_0.REALM_ID=? 
ORDER BY o1_0.NAME 
LIMIT ?,?
```

The lowercase of the `NAME` and `VALUE` columns in the `ORGANIZATION_ATTRIBUTE` table is causing a performance overhead and more importantly prevents us from creating an index on either column, or a compound one `name() + value()`.

Removing the lowercasing and creating the index will significantly speed up the query. The logic isn't nesscary for Fastly's internal workloads as we will always be comparing valid data where we are happy for case-senesitve data, and MySQL's comparision is case-insensitive by default.