### PR TITLE
Fix NPE in Fastly implementation of HomeIdpDiscoverer when no user found

### DIFF
--- a/src/main/java/io/phasetwo/service/auth/idp/HomeIdpDiscoverer.java
+++ b/src/main/java/io/phasetwo/service/auth/idp/HomeIdpDiscoverer.java
@@ -76,6 +76,12 @@ final class HomeIdpDiscoverer {
         return homeIdps;
     }
 
+    // Note(fastly):
+    //
+    // Original upstream implementation of discoverHomeIdps
+    // See next function for Fastly implementation.
+    //
+    /*
     private List<IdentityProviderModel> discoverHomeIdps(Domain domain, UserModel user, String username) {
         final Map<String, String> linkedIdps;
 
@@ -101,15 +107,63 @@ final class HomeIdpDiscoverer {
         List<IdentityProviderModel> enabledIdpsWithMatchingDomain = filterIdpsWithMatchingDomainFrom(enabledIdps,
             domain,
             config);
-        */
+        *//*
         // Overidden lookup mechanism to lookup via organization domain
-        /* OrganizationProvider orgs = context.getSession().getProvider(OrganizationProvider.class);
+        OrganizationProvider orgs = context.getSession().getProvider(OrganizationProvider.class);
         List<IdentityProviderModel> enabledIdpsWithMatchingDomain =
             orgs.getOrganizationsStreamForDomain(
                     context.getRealm(), domain.toString(), config.requireVerifiedDomain())
                 .flatMap(o -> o.getIdentityProvidersStream())
                 .filter(IdentityProviderModel::isEnabled)
-                .collect(Collectors.toList()); */
+                .collect(Collectors.toList());
+
+        // Prefer linked IdP with matching domain first
+        List<IdentityProviderModel> homeIdps = getLinkedIdpsFrom(enabledIdpsWithMatchingDomain, linkedIdps);
+
+        if (homeIdps.isEmpty()) {
+            if (!linkedIdps.isEmpty()) {
+                // Prefer linked and enabled IdPs without matching domain in favor of not linked IdPs with matching domain
+                homeIdps = getLinkedIdpsFrom(enabledIdps, linkedIdps);
+            }
+            if (homeIdps.isEmpty()) {
+                // Fallback to not linked IdPs with matching domain (general case if user logs in for the first time)
+                homeIdps = enabledIdpsWithMatchingDomain;
+                logFoundIdps("non-linked", "matching", homeIdps, domain, username);
+            } else {
+                logFoundIdps("non-linked", "non-matching", homeIdps, domain, username);
+            }
+        } else {
+            logFoundIdps("linked", "matching", homeIdps, domain, username);
+        }
+
+        return homeIdps;
+    }
+    */
+
+    // Note(fastly):
+    //
+    // Fastly implementation of discoverHomeIdps
+    // See above function for original implementation.
+    //
+    private List<IdentityProviderModel> discoverHomeIdps(Domain domain, UserModel user, String username) {
+        final Map<String, String> linkedIdps;
+
+        HomeIdpDiscoveryConfig config = new HomeIdpDiscoveryConfig(context.getAuthenticatorConfig());
+        if (user == null || !config.forwardToLinkedIdp()) {
+            LOG.tracef(
+                "User '%s' is not stored locally or forwarding to linked IdP is disabled. Skipping discovery of linked IdPs.",
+                username);
+            return Collections.emptyList();
+        }
+
+        LOG.tracef(
+            "Found local user '%s' and forwarding to linked IdP is enabled. Discovering linked IdPs.",
+            username);
+
+        linkedIdps = context.getSession().users()
+                .getFederatedIdentitiesStream(context.getRealm(), user)
+                .collect(
+                    Collectors.toMap(FederatedIdentityModel::getIdentityProvider, FederatedIdentityModel::getUserName));
 
         // Custom Fastly lookup mechanism.
         //
@@ -119,7 +173,7 @@ final class HomeIdpDiscoverer {
         // 2. Filter to only enabled IdPs
         String clientID = context.getAuthenticationSession().getClient().getClientId();
         OrganizationProvider orgs = context.getSession().getProvider(OrganizationProvider.class);
-        List<IdentityProviderModel> enabledIdpsWithMatchingDomain =
+        List<IdentityProviderModel> enabledIdpsForUserOrgs =
             orgs.getUserOrganizationsStream(
                     context.getRealm(), user)
                 .filter(o -> {
@@ -138,24 +192,7 @@ final class HomeIdpDiscoverer {
                 .filter(IdentityProviderModel::isEnabled)
                 .collect(Collectors.toList());
 
-        // Prefer linked IdP with matching domain first
-        List<IdentityProviderModel> homeIdps = getLinkedIdpsFrom(enabledIdpsWithMatchingDomain, linkedIdps);
-
-        /* if (homeIdps.isEmpty()) {
-            if (!linkedIdps.isEmpty()) {
-                // Prefer linked and enabled IdPs without matching domain in favor of not linked IdPs with matching domain
-                homeIdps = getLinkedIdpsFrom(enabledIdps, linkedIdps);
-            }
-            if (homeIdps.isEmpty()) {
-                // Fallback to not linked IdPs with matching domain (general case if user logs in for the first time)
-                homeIdps = enabledIdpsWithMatchingDomain;
-                logFoundIdps("non-linked", "matching", homeIdps, domain, username);
-            } else {
-                logFoundIdps("non-linked", "non-matching", homeIdps, domain, username);
-            }
-        } else {
-            logFoundIdps("linked", "matching", homeIdps, domain, username);
-        } */
+        List<IdentityProviderModel> homeIdps = getLinkedIdpsFrom(enabledIdpsForUserOrgs, linkedIdps);
 
         logFoundIdps("linked", "matching", homeIdps, domain, username);
 


### PR DESCRIPTION
⚠️ This is a PR into Fastly's base branch `fastly` and not the upstream origin's `main`.

---

### What?
Fixes a `NullPointerExeception` in the Fastly implementation of the home realm discovery logic. The previous logic would continue processing if there was no user entity and then attempted to search for orgs by user which would throw the NPE. We now return early from the function if no user is passed.

### Note
The diff is larger than expected as I created an entire copy of the method for us to have a cleaner distinction between the original/upstream implementation and our own.