### PR TITLE
Home realm discovery default CID selection

### DIFF
--- a/src/main/java/io/phasetwo/service/auth/idp/HomeIdpDiscoverer.java
+++ b/src/main/java/io/phasetwo/service/auth/idp/HomeIdpDiscoverer.java
@@ -16,6 +16,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
+import java.util.Objects;
 
 final class HomeIdpDiscoverer {
 
@@ -173,6 +174,10 @@ final class HomeIdpDiscoverer {
         // 2. Filter to only enabled IdPs
         String clientID = context.getAuthenticationSession().getClient().getClientId();
         OrganizationProvider orgs = context.getSession().getProvider(OrganizationProvider.class);
+        String userDefaultCID = Objects.toString(
+                user.getFirstAttribute("default_cid"),
+            "");
+
         List<IdentityProviderModel> enabledIdpsForUserOrgs =
             orgs.getUserOrganizationsStream(
                     context.getRealm(), user)
@@ -187,6 +192,10 @@ final class HomeIdpDiscoverer {
                     String forceSSO = o.getFirstAttribute("force_sso");
                     boolean hasForceSSO = forceSSO != null && forceSSO.equals("1");
                     return hasCID && hasForceSSO;
+                })
+                .sorted((o1, o2) -> {
+                    if(o1.getFirstAttribute("customer_id") == userDefaultCID) return -1;
+                    else return 1;
                 })
                 .flatMap(o -> o.getIdentityProvidersStream())
                 .filter(IdentityProviderModel::isEnabled)


### PR DESCRIPTION
⚠️ This is a PR into Fastly's base branch `fastly` and not the upstream origin's `main`.

---

### What?
Ensure that we attempt to select the users "default org" when performing home realm disocvery; by sorting the list of orgs based on the users `default_cid` attribute.