### PR TITLE
Fix IdP discovery bug for Fastly + Sigsci users

### DIFF
--- a/src/main/java/io/phasetwo/service/auth/idp/HomeIdpDiscoverer.java
+++ b/src/main/java/io/phasetwo/service/auth/idp/HomeIdpDiscoverer.java
@@ -194,15 +194,19 @@ final class HomeIdpDiscoverer {
                     return hasCID && hasForceSSO;
                 })
                 .sorted((o1, o2) -> {
-                    String corp_id = o.getFirstAttribute("corp_id");
-                    String customer_id = o.getFirstAttribute("customer_id");
-                    if(clientID.equals("sigsci-dashboard") && corp_id != null && !corp_id.isEmpty()) {
-                        return -1;
+                    if(clientID.equals("sigsci-dashboard")) {
+                        String corp_id = o1.getFirstAttribute("corp_id");
+                        if(corp_id != null && !corp_id.isEmpty()) {
+                            return -1;
+                        }
                     }
-                    if(!clientID.equals("sigsci-dashboard") && customer_id != null && !customer_id.isEmpty()) {
-                        return -1;
+                    else {
+                        String customer_id = o1.getFirstAttribute("customer_id");
+                        if(customer_id != null && !customer_id.isEmpty()) {
+                            return -1;
+                        }
                     }
-                    else return 1;
+                    return 1;
                 })
                 .sorted((o1, o2) -> {
                     if(o1.getFirstAttribute("customer_id") == userDefaultCID) return -1;

--- a/src/main/java/io/phasetwo/service/auth/idp/HomeIdpDiscoverer.java
+++ b/src/main/java/io/phasetwo/service/auth/idp/HomeIdpDiscoverer.java
@@ -194,6 +194,17 @@ final class HomeIdpDiscoverer {
                     return hasCID && hasForceSSO;
                 })
                 .sorted((o1, o2) -> {
+                    String corp_id = o.getFirstAttribute("corp_id");
+                    String customer_id = o.getFirstAttribute("customer_id");
+                    if(clientID.equals("sigsci-dashboard") && corp_id != null && !corp_id.isEmpty()) {
+                        return -1;
+                    }
+                    if(!clientID.equals("sigsci-dashboard") && customer_id != null && !customer_id.isEmpty()) {
+                        return -1;
+                    }
+                    else return 1;
+                })
+                .sorted((o1, o2) -> {
                     if(o1.getFirstAttribute("customer_id") == userDefaultCID) return -1;
                     else return 1;
                 })


### PR DESCRIPTION
Update the IdP discovery logic for users with multiple IdPs so that

- If user is logging in via SigSci client, SigSci IdP will take precedence
- If user is logging in via any other client, Fastly IdPs will take precedence