### PR TITLE
use client note for home idp discovery

### DIFF
--- a/src/main/java/io/phasetwo/service/auth/idp/HomeIdpDiscoverer.java
+++ b/src/main/java/io/phasetwo/service/auth/idp/HomeIdpDiscoverer.java
@@ -157,7 +157,7 @@ final class HomeIdpDiscoverer {
                     else return 1;
                 })
                 .sorted((o1, o2) -> {
-                    String accountHint = authSession.getAuthNote(
+                    String accountHint = authSession.getClientNote(
                         ACCOUNT_HINT_QUERY_PARAM
                     );
                     String customerID = o1.getFirstAttribute("customer_id");


### PR DESCRIPTION
The `account_hint` query parameter is not stored into an auth note by keycloak-core, it is stored by default into a client note. When we try to reach for an auth note during home IDP discovery currently the `account_hint` will be `null` and won't redirect to the correct IDP.