### PR TITLE
add named query for querying for organization users by federation link

### DIFF
--- a/src/main/java/io/phasetwo/service/model/jpa/entity/OrganizationMemberEntity.java
+++ b/src/main/java/io/phasetwo/service/model/jpa/entity/OrganizationMemberEntity.java
@@ -44,7 +44,11 @@ import java.util.Objects;
           query = "SELECT m FROM OrganizationMemberEntity m WHERE m.userId = :userId AND m.organization = :organization"),
   @NamedQuery(
       name = "getOrganizationMembershipsByUserId",
-      query = "SELECT m FROM OrganizationMemberEntity m WHERE m.userId = :userId")
+      query = "SELECT m FROM OrganizationMemberEntity m WHERE m.userId = :userId"),
+  @NamedQuery(
+      name = "getOrganizationMembershipsByUserFederationLink",
+      query = "SELECT m FROM OrganizationMemberEntity m INNER JOIN UserEntity u on m.user_id = u.id WHERE u.realmId = :realmId AND u.federationLink=:link"
+  )
 })
 @Table(
     name = "ORGANIZATION_MEMBER",

--- a/src/main/java/io/phasetwo/service/model/jpa/entity/OrganizationMemberEntity.java
+++ b/src/main/java/io/phasetwo/service/model/jpa/entity/OrganizationMemberEntity.java
@@ -47,7 +47,7 @@ import java.util.Objects;
       query = "SELECT m FROM OrganizationMemberEntity m WHERE m.userId = :userId"),
   @NamedQuery(
       name = "getOrganizationMembershipsByUserFederationLink",
-      query = "SELECT m FROM OrganizationMemberEntity m INNER JOIN UserEntity u on m.user_id = u.id WHERE u.realmId = :realmId AND u.federationLink=:link"
+      query = "SELECT m FROM OrganizationMemberEntity m INNER JOIN UserEntity u on m.userId = u.id WHERE u.realmId = :realmId AND u.federationLink=:link"
   )
 })
 @Table(


### PR DESCRIPTION
As part of the federated users rollout we will need to delete users that have the federation link attribute set on them to remove their local storage users. Currently the KC functionality for this does not delete org memberships that the user was associated with and there are no existing queries for pulling users / memberships by federation link. Adding the query here.