### PR TITLE
use correct equality check for default_cid

### DIFF
--- a/src/main/java/io/phasetwo/service/auth/idp/HomeIdpDiscoverer.java
+++ b/src/main/java/io/phasetwo/service/auth/idp/HomeIdpDiscoverer.java
@@ -153,7 +153,7 @@ final class HomeIdpDiscoverer {
                     return 1;
                 })
                 .sorted((o1, o2) -> {
-                    if(o1.getFirstAttribute("customer_id") == userDefaultCID) return -1;
+                    if(o1.getFirstAttribute("customer_id").equals(userDefaultCID)) return -1;
                     else return 1;
                 })
                 .sorted((o1, o2) -> {


### PR DESCRIPTION
should be using `.equals()` for checking default CID string equality