### PR TITLE
Update homeidpdiscovery to account for fastly organizations

### DIFF
--- a/src/main/java/io/phasetwo/service/auth/idp/HomeIdpDiscoverer.java
+++ b/src/main/java/io/phasetwo/service/auth/idp/HomeIdpDiscoverer.java
@@ -149,6 +149,11 @@ final class HomeIdpDiscoverer {
                         if(customer_id != null && !customer_id.isEmpty()) {
                             return -1;
                         }
+
+                        String organizationID = o1.getFirstAttribute("organization_id");
+                        if(organizationID != null && !organizationID.isEmpty()) {
+                            return -1;
+                        }
                     }
                     return 1;
                 })
@@ -163,6 +168,13 @@ final class HomeIdpDiscoverer {
                     String customerID = o1.getFirstAttribute("customer_id");
                     if (accountHint != null && !accountHint.isEmpty() &&
                         customerID != null && !customerID.isEmpty() &&
+                        accountHint == customerID) {
+                        return -1;
+                    }
+
+                    String organizationID = o1.getFirstAttribute("organization_id");
+                    if (accountHint != null && !accountHint.isEmpty() &&
+                        organizationID != null && !organizationID.isEmpty() &&
                         accountHint == customerID) {
                         return -1;
                     }
@@ -190,7 +202,10 @@ final class HomeIdpDiscoverer {
         String customerID = org.getFirstAttribute("customer_id");
         boolean hasCustomerID = customerID != null && !customerID.isEmpty();
 
-        return hasCustomerID;
+        String organizationID = org.getFirstAttribute("organization_id");
+        boolean hasOrganizationID = organizationID != null & !organizationID.isEmpty();
+
+        return hasCustomerID || hasOrganizationID;
     }
 
     private boolean hasForceSso(OrganizationModel org) {

--- a/src/main/java/io/phasetwo/service/auth/idp/HomeIdpDiscoverer.java
+++ b/src/main/java/io/phasetwo/service/auth/idp/HomeIdpDiscoverer.java
@@ -175,7 +175,7 @@ final class HomeIdpDiscoverer {
                     String organizationID = o1.getFirstAttribute("organization_id");
                     if (accountHint != null && !accountHint.isEmpty() &&
                         organizationID != null && !organizationID.isEmpty() &&
-                        accountHint == customerID) {
+                        accountHint == organizationID) {
                         return -1;
                     }
                     return 1;


### PR DESCRIPTION
Adds support for `organization_id` wherever we check for the existence of `customer_id` so that we can support fastly organizations with `force_sso` via home IDP discovery